### PR TITLE
Mac OS configuration

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -50,7 +50,15 @@
                             ]
                         ]
                     }
-                ]
+                ],
+                [ 'OS=="mac"', {
+                  'xcode_settings': {
+                    'OTHER_CPLUSPLUSFLAGS' : ['-std=c++11','-stdlib=libc++', '-v'],
+                    'OTHER_LDFLAGS': ['-stdlib=libc++'],
+                    'MACOSX_DEPLOYMENT_TARGET': '10.7',
+                    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                  },
+                }]
             ]
         }
     ]


### PR DESCRIPTION
"node-gyp configure build" throws errors during compilation on Mac OS. Those can be eliminated by using C++11 compiler
