### PR TITLE
Prepublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /buildjs
 /node_modules
 /typings
+/.nyc_output/
+/coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,13 @@ before_install:
   - node --version
   - npm --version
   - gcc --version
-  - npm install typescript -g
-  - npm install typings -g
-  - npm install mocha -g
-  - typings install
-  - tsc
+  - npm install coveralls
 
 script:
-  - npm test
+  - npm run coverage
+
+after_success:
+  - npm run coveralls
 
 cache:
   directories:

--- a/.waiting.html
+++ b/.waiting.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Code coverage report for All files</title>
+  <style>
+body {
+    font-family: Helvetica Neue, Helvetica, Arial;
+    font-size: 20px;
+    color:#333;
+    margin: 50px;
+}
+code {
+  color: green;
+}
+  </style>
+</head>
+<body>
+  <div>This page will refresh with a coverage report, as long as you have
+    executed <code>npm run dev</code>.  Please be patient.</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,10 +8,19 @@
   "description": "A WebCrypto Polyfill for Node in TypeScript built on OpenSSL",
   "main": "buildjs/webcrypto.js",
   "scripts": {
+    "pretest": "npm run build",
     "test": "mocha",
-    "build": "typings install && tsc",
+    "build": "typings install && tsc --sourceMap",
     "pub": "npm version patch && npm publish && git push",
-    "sync": "git ac && git pull --rebase && git push"
+    "sync": "git ac && git pull --rebase && git push",
+    "coverage": "nyc npm test",
+    "precoveragehtml": "npm run coverage",
+    "coveragehtml": "nyc report -r html",
+    "watch": "watch 'npm run coveragehtml' lib/ src/ test/",
+    "live": "live-server -q --port=4005 --ignorePattern='(js|css|png)$' coverage",
+    "predev": "if [ ! -f coverage/index.html ]; then mkdir coverage; cp .waiting.html coverage/index.html; fi",
+    "dev": "npm-run-all -p --silent watch live",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "author": "PeculiarVentures",
   "license": "MIT",
@@ -28,5 +37,14 @@
   "dependencies": {
     "mkdirp": "^0.5.1",
     "nan": "^2.4.0"
+  },
+  "devDependencies": {
+    "live-server": "^1",
+    "mocha": "^3",
+    "npm-run-all": "^3",
+    "nyc": "^8",
+    "typescript": "^1.8.10",
+    "typings": "^1.3.3",
+    "watch": "^0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "description": "A WebCrypto Polyfill for Node in TypeScript built on OpenSSL",
   "main": "buildjs/webcrypto.js",
   "scripts": {
+    "clean": "rm -rf build/ buildjs/ coverage/ .nyc_output/ npm-debug.log npm-debug.log.*",
+    "prepublish": "npm run build",
+    "postinstall": "npm run build",
     "pretest": "npm run build",
     "test": "mocha",
     "build": "typings install && tsc --sourceMap",

--- a/typings.json
+++ b/typings.json
@@ -4,5 +4,10 @@
   },
   "dependencies": {
     "mkdirp": "registry:npm/mkdirp#0.5.0+20160723033700"
+  },
+  "globalDevDependencies": {
+    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
+    "typescript": "registry:dt/typescript#0.4.0+20160317120654",
+    "watch": "registry:dt/watch#0.0.0+20160316155526"
   }
 }


### PR DESCRIPTION
Fixes #50.  To prove: `npm install hildjj/node-webcrypto-ossl#prepublish`
Depends on #71.  Fixes the TODO from there.  I decided #50 was the feature request.

This should also help prevent publishing to npm without having run tsc.