### PR TITLE
Move node types to a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
     "polyfill"
   ],
   "dependencies": {
-    "@types/node": "^6",
     "mkdirp": "^0.5.1",
     "nan": "^2.5.1",
     "tslib": "^1.7.1",
     "webcrypto-core": "^0.1.16"
   },
   "devDependencies": {
+    "@types/node": "^6",
     "@types/mkdirp": "^0.3.29",
     "live-server": "^1",
     "mocha": "^3.4.2",


### PR DESCRIPTION
I'd love to use this as a polyfill in the test environment for my browser-based typescript projects, but it's non-usable as long as it (and webcrypto-core) has a hard dependency on node types. Unfortunately typescript loads all @types packages it finds in your node_modules folder, so it means that having this installed in my web-based project will clobber the global type namespace with all the global stuff node has. Works beautifully for my simple purposes once the types aren't in uproar, though. ❤️ 