### PR TITLE
Use correct byteOffset when slicing an ArrayBufferView, Fixes #116

### DIFF
--- a/lib/subtle.ts
+++ b/lib/subtle.ts
@@ -31,9 +31,9 @@ function ab2b(ab: NodeBufferSource) {
         return ab;
     } else if (ArrayBuffer.isView(ab)) {
         // NOTE: ab.buffer can have another size than view after ArrayBufferView.subarray
-        return new Buffer(ab.buffer.slice(0, ab.byteLength));
+        return Buffer.from(ab.buffer, ab.byteOffset, ab.byteLength);
     } else {
-        return new Buffer(ab);
+        return Buffer.from(ab);
     }
 }
 


### PR DESCRIPTION
Aside: This commit uses the `Buffer.from` syntax introduced sometime before node v.4.x.

Since the library didn't seem to install on node <= v.0.12.6, I thought this was acceptable.