### PR TITLE
Note about dependencies missing from some Linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ We wanted to be able to write Javascript that used crypto on both the client and
 ### npm
 
 ```
+# Depends on python and openssl
 npm install node-webcrypto-ossl;
 ```
 


### PR DESCRIPTION
It's better to let people know about dependencies than finding the in deployment errors.

```
error /app/node_modules/node-webcrypto-ossl: Command failed.
Exit code: 1
Command: node-gyp rebuild
Arguments: 
Directory: /app/node_modules/node-webcrypto-ossl
Output:
gyp info it worked if it ends with ok
gyp info using node-gyp@5.1.0
gyp info using node@14.17.3 | linux | x64
gyp ERR! find Python 
```